### PR TITLE
add .ts, .tsx and .jsx to the default tsserver config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -397,7 +397,7 @@ lspconfig.sumneko_lua = add_lsp {
 lspconfig.tsserver = add_lsp {
   name = "typescript-language-server",
   language = "javascript",
-  file_patterns = { "%.js$", "%.cjs$", "%.mjs$" },
+  file_patterns = { "%.jsx?$", "%.cjs$", "%.mjs$", "%.tsx?$" },
   command = { 'typescript-language-server', '--stdio' },
   verbose = false
 }


### PR DESCRIPTION
Probably an oversight of the default configuration. Gave it a quick test, seems to be working fine even with JSX files.