### PR TITLE
Fixed redundant comma symbols at line/column 154/38 and 158/43

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ Configuration options that can be used to control the plugin behaviour:
 ```lua
 ---Show a symbol hover information when mouse cursor is on top.
 ---@type boolean
-config.plugins.lsp.mouse_hover = true,
+config.plugins.lsp.mouse_hover = true
 
 ---The amount of time in milliseconds before showing the tooltip.
 ---@type integer
-config.plugins.lsp.mouse_hover_delay = 300,
+config.plugins.lsp.mouse_hover_delay = 300
 
 ---Show diagnostic messages
 ---@type boolean


### PR DESCRIPTION
While I was setting up the LSP plugin configuration I noticed that if I copied the LSP plugins configuration options code block and saved my init.lua, Lite XL returned a log error page that indicated that there were errors at line/column  154/38 and 158/43.

If I'm not mistaken, commas aren't meant to be there.