### PR TITLE
Add jdtls to language servers

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -329,11 +329,10 @@ lspconfig.intelephense = add_lsp {
 ---# java
 --- __Status__: Works
 --- __Site__: https://github.com/eclipse/eclipse.jdt.ls
---- __Note__: You must have a native executable which runs the python files provided when using on windows
 lspconfig.jdtls = add_lsp {
   name = "jdtls",
   language = "java",
-  file_patterns = { "%.java$", "%.mvn$", "%.gradle$" },
+  file_patterns = { "%.java$" },
   command = { "jdtls" },
   verbose = false
 }

--- a/config.lua
+++ b/config.lua
@@ -326,6 +326,18 @@ lspconfig.intelephense = add_lsp {
   verbose = false
 }
 
+---# java
+--- __Status__: Works
+--- __Site__: https://github.com/eclipse/eclipse.jdt.ls
+--- __Note__: You must have a native executable which runs the python files provided when using on windows
+lspconfig.jdtls = add_lsp {
+  name = "jdtls",
+  language = "java",
+  file_patterns = { "%.java$", "%.mvn$", "%.gradle$" },
+  command = { "jdtls" },
+  verbose = false
+}
+
 ---# vscode-json-languageserver
 --- __Status__: Works
 --- __Site__: https://www.npmjs.com/package/vscode-json-languageserver


### PR DESCRIPTION
![image](https://github.com/lite-xl/lite-xl-lsp/assets/62295632/88866e40-97e0-4567-a11f-957780407c34)
I had to use a hacky workaround to get this to run on windows by making an executable to run the normal python script. In future, the command should be `python /path/to/jdtls`.

```c
#include <stdlib.h>
#include <string.h>

int main(int argc, char *argv[]) {
    char python_script[] = "path\\to\\jdtls";
    char command[200] = "python ";

    strcat(command, python_script);

    for (int i = 1; i < argc; i++) {
        strcat(command, " ");
        strcat(command, argv[i]);
    }

    system(command);

    return 0;
}

```
