### PR TITLE
On Windows, run servers using `cmd.exe`

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -47,6 +47,8 @@ end
 ---@field file_patterns string[]
 ---LSP command and optional arguments.
 ---@field command table<integer,string|table>
+---On Windows, avoid running the LSP server with cmd.exe.
+---@field windows_skip_cmd boolean
 ---Optional table of settings to pass into the lsp
 ---Note that also having a settings.json or settings.lua in
 ---your workspace directory with a table of settings is supported.

--- a/init.lua
+++ b/init.lua
@@ -606,6 +606,13 @@ function lsp.add_server(options)
     options.command[1] = util.get_best_executable(options.command[1])
   end
 
+  -- On Windows using cmd.exe allows us to take advantage of its ability to run
+  -- the correct executable, as well as running scripts.
+  if PLATFORM == "Windows" and not options.windows_skip_cmd then
+    table.insert(options.command, 1, "/C")
+    table.insert(options.command, 1, "cmd.exe")
+  end
+
   if config.plugins.lsp.force_verbosity_off then
     options.verbose = false
   end

--- a/server.lua
+++ b/server.lua
@@ -64,6 +64,7 @@ local Server = Object:extend()
 ---@field language string
 ---@field file_patterns table<integer, string>
 ---@field command table<integer, string>
+---@field windows_skip_cmd boolean
 ---@field settings table
 ---@field init_options table
 ---@field requests_per_second number
@@ -78,6 +79,8 @@ Server.options = {
   file_patterns = {},
   ---Command to launch LSP server and optional arguments
   command = {},
+  ---On Windows, avoid running the LSP server with cmd.exe
+  windows_skip_cmd = false,
   ---Optional table of settings to pass into the lsp
   ---Note that also having a settings.json or settings.lua in
   ---your workspace directory is supported


### PR DESCRIPTION
This should solve issues like running executables with different extensions (or none) and batch scripts.

This probably makes the Windows part of `util.command_exists` useless, so a different method to detect missing executables is needed (maybe `cmd.exe` exit codes can tell us something?).

Testing needed.