### PR TITLE
Add fennel-ls to the list of servers.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -235,6 +235,23 @@ lspconfig.deno = add_lsp {
   }
 }
 
+---# fennel-ls
+--- __Status__: Untested
+--- __Site__: https://git.sr.ht/~xerool/fennel-ls
+--- __Installation__:
+--- ```sh
+--- git clone https://git.sr.ht/~xerool/fennel-ls
+--- make -C fennel-ls
+--- sudo make -C fennel-ls install
+--- ```
+lspconfig.fennells = add_lsp {
+  name = "fennel-ls",
+  language = "fennel",
+  file_patterns = { "%.fnl$" },
+  command = { "fennel-ls" },
+  verbose = false
+}
+
 ---# Flow - JavaScript
 --- __Status__: Untested
 --- __Site__: https://flow.org/


### PR DESCRIPTION
This adds support for the `fennel-ls` language server. However, when I try to run it, I can't manage to get it to activate with `.fnl` files within lite-xl. The `Lsp:` commands show up and can be invoked, but they don't have any effect. The log tab doesn't show anything about trying to start the server, and `ps` shows that it is never launched.

Would appreciate some guidance about what I'm doing wrong; thanks.