### PR TITLE
Add F# support via fsharp-language-server.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -505,6 +505,18 @@ lspconfig.omnisharp = add_lsp {
   verbose = false
 }
 
+---# F# - fsharp-language-server
+--- __Status__: Works
+--- __Site__: https://github.com/fsprojects/fsharp-language-server
+--- __Installation__: https://github.com/fsprojects/fsharp-language-server?tab=readme-ov-file#installation
+lspconfig.fsharp_ls = add_lsp {
+  name = "fsharp_ls",
+  language = "f#",
+  file_patterns = { "%.fs$", "%.fsh$" },
+  command = { "dotnet", "fsharp-language-server" },
+  verbose = false
+}
+
 ---# PerlNavigator - Perl
 --- __Status__: Works
 --- __Site__: https://github.com/bscan/PerlNavigator


### PR DESCRIPTION
This Pr is still WIP, because the fsharp configuration supplied by `add_lsp()` is not complete yet.