### PR TITLE
Allow specifying custom `capabilities` that will be sent on `initialize`

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -37,6 +37,8 @@ local snippets = pcall(require, "plugins.snippets") and config.plugins.lsp.snipp
 ---@field settings table<string,any>
 ---Optional table of initializationOptions for the LSP.
 ---@field init_options table<string,any>
+---Optional table of capabilities that will be merged with our default one.
+---@field custom_capabilities table<string,any>
 ---Function called when the server has been started.
 ---@field on_start? fun(server: lsp.server)
 ---Set by default to 16 should only be modified if having issues with a server.


### PR DESCRIPTION
This is useful for plugins that want to for example implement server-specific capabilities.

This can also be used with LSP servers that don't behave as expected when some capabilities are enabled.
For example https://github.com/lite-xl/lite-xl/discussions/485#discussioncomment-8448386 can now be worked around by setting
```lua
custom_capabilities = {
  workspace = {
    configuration = false
  }
}
```