### PR TITLE
Improve `languageId` selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ lsp.add_server {
   name = "intelephense",
   -- Main language
   language = "PHP",
+  -- If the server supports multiple languages:
+  -- language = {
+  --   { id = "javascript", pattern = "%.js$" },
+  --   { id = "typescript", pattern = "%.ts$" },
+  -- }
+  -- If no pattern matches, the file extension is used instead.
   -- File types that are supported by this server
   file_patterns = { "%.php$" },
   -- LSP command and optional arguments

--- a/config.lua
+++ b/config.lua
@@ -20,7 +20,13 @@ local snippets = pcall(require, "plugins.snippets") and config.plugins.lsp.snipp
 ---Name of server.
 ---@field name string
 ---Main language, eg: C.
----@field language string
+---Can be a string or a table.
+---If the table is empty, the file extension will be used instead.
+---The table should be an array of tables containing `id` and `pattern`.
+---The `pattern` will be matched with the file path.
+---Will use the `id` of the first `pattern` that matches.
+---If no pattern matches, the file extension will be used instead.
+---@field language string | lsp.server.languagematch[]
 ---File types that are supported by this server.
 ---@field file_patterns string[]
 ---LSP command and optional arguments.
@@ -82,7 +88,7 @@ local lspconfig = {}
 --- __Note__: also install `shellcheck` for linting
 lspconfig.bashls = add_lsp {
   name = "bash-language-server",
-  language = "shell",
+  language = "shellscript",
   file_patterns = { "%.sh$" },
   command = { "bash-language-server", "start" },
   incremental_changes = true,
@@ -95,7 +101,12 @@ lspconfig.bashls = add_lsp {
 --- __Installation__: https://github.com/MaskRay/ccls/wiki
 lspconfig.ccls = add_lsp {
   name = "ccls",
-  language = "c/cpp",
+  language = {
+    { id = "c",   pattern = "%.[ch]$"     },
+    { id = "cpp", pattern = "%.[ch]pp$"   },
+    { id = "cpp", pattern = "%.[CH]$"     },
+    { id = "cpp", pattern = "%.[ch]%+%+$" },
+  },
   file_patterns = {
     "%.c$", "%.h$", "%.inl$", "%.cpp$", "%.hpp$",
     "%.cc$", "%.C$", "%.cxx$", "%.c++$", "%.hh$",
@@ -112,7 +123,12 @@ lspconfig.ccls = add_lsp {
 --- __Note__: See https://clangd.llvm.org/installation.html#project-setup
 lspconfig.clangd = add_lsp {
   name = "clangd",
-  language = "c/cpp",
+  language = {
+    { id = "c",   pattern = "%.[ch]$"     },
+    { id = "cpp", pattern = "%.[ch]pp$"   },
+    { id = "cpp", pattern = "%.[CH]$"     },
+    { id = "cpp", pattern = "%.[ch]%+%+$" },
+  },
   file_patterns = {
     "%.c$", "%.h$", "%.inl$", "%.cpp$", "%.hpp$",
     "%.cc$", "%.C$", "%.cxx$", "%.c++$", "%.hh$",
@@ -197,10 +213,14 @@ lspconfig.dartls = add_lsp {
 --- __Installation__: Provided in Deno runtime
 lspconfig.deno = add_lsp {
   name = "deno",
-  language = "typescript",
-  file_patterns = { "%.ts$", "%.tsx$" },
+  language = {
+    { id = "javascript",      pattern = "%.js$"  },
+    { id = "javascriptreact", pattern = "%.jsx$" },
+    { id = "typescript",      pattern = "%.ts$"  },
+    { id = "typescriptreact", pattern = "%.tsx$" },
+  },
+  file_patterns = { "%.[tj]s$", "%.[tj]sx$" },
   command = { 'deno', 'lsp' },
-  id_not_extension = true,
   verbose = false,
   settings = {
     deno = {
@@ -327,10 +347,10 @@ lspconfig.fortls = add_lsp {
 --- __Site__: https://gleam.run/
 --- __Installation__: Included with the gleam compiler binary
 lspconfig.gleam = add_lsp {
-	name = 'gleam',
-	language = 'gleam',
-	file_patterns = { '%.gleam$' },
-	command = { 'gleam', 'lsp' },
+	name = "gleam",
+	language = "gleam",
+	file_patterns = { "%.gleam$" },
+	command = { "gleam", "lsp" },
 	verbose = false
 }
 
@@ -501,7 +521,7 @@ lspconfig.nillsp = add_lsp {
 --- __Installation__: `nimble install nimlsp`
 lspconfig.nimlsp = add_lsp {
   name = "nimlsp",
-  language = "Nim",
+  language = "nim",
   file_patterns = { "%.nim$" },
   command = { "nimlsp" },
   requests_per_second = 25,
@@ -518,7 +538,6 @@ lspconfig.ocaml_lsp = add_lsp {
   language = "ocaml",
   file_patterns = { "%.ml$", "%.mli$" },
   command = { "ocamllsp" },
-  id_not_extension = true,
   verbose = false
 }
 
@@ -540,7 +559,7 @@ lspconfig.odinls = add_lsp {
 --- __Installation__: See official website for instructions
 lspconfig.omnisharp = add_lsp {
   name = "omnisharp",
-  language = "c#",
+  language = "csharp",
   file_patterns = { "%.cs$" },
   command = { "omnisharp", "-lsp" },
   verbose = false
@@ -552,7 +571,7 @@ lspconfig.omnisharp = add_lsp {
 --- __Installation__: `paru -S perlnavigator`
 lspconfig.perlnavigator = add_lsp {
   name = "perlnavigator",
-  language = "Perl",
+  language = "perl",
   file_patterns = { "%.pl$", "%.pm$" },
   command = { "perlnavigator" },
   settings = {
@@ -609,9 +628,15 @@ lspconfig.pyright = add_lsp {
 --- __Installation__: Arch Linux: `yay -Syu quick-lint-js`
 lspconfig.quicklintjs = add_lsp {
   name = "quick-lint-js",
-  language = "javascript",
-  file_patterns = { "%.[mc]?js$" },
-  id_not_extension = true,
+  language = {
+    { id = "javascriptreact",      pattern = "%.jsx$"   },
+    { id = "javascript",           pattern = "%.js$"    },
+    { id = "typescriptdefinition", pattern = "%.d%.ts$" },
+    { id = "typescriptsource",     pattern = "%.ts$"    },
+    { id = "typescriptreact",      pattern = "%.tsx$"   },
+    { id = "typescript",           pattern = ".*"       },
+  },
+  file_patterns = { "%.[mc]?jsx?$", "%.tsx?$" },
   command = { "quick-lint-js", "--lsp-server" },
   verbose = false
 }
@@ -829,8 +854,13 @@ lspconfig.taplo = add_lsp {
 --- __Installation__: `npm install -g typescript-language-server typescript`
 lspconfig.tsserver = add_lsp {
   name = "typescript-language-server",
-  language = "javascript",
-  file_patterns = { "%.jsx?$", "%.cjs$", "%.mjs$", "%.tsx?$" },
+  language = {
+    { id = "javascript",      pattern = "%.[cm]?js$"  },
+    { id = "javascriptreact", pattern = "%.jsx$"      },
+    { id = "typescript",      pattern = "%.ts$"       },
+    { id = "typescriptreact", pattern = "%.tsx$"      },
+  },
+  file_patterns = { "%.jsx?$", "%.[cm]js$", "%.tsx?$" },
   command = { 'typescript-language-server', '--stdio' },
   verbose = false
 }

--- a/init.lua
+++ b/init.lua
@@ -562,15 +562,6 @@ end
 -- Public functions
 --
 
----Get a language server languageId from language identifier or file extension
----depending on the "id_not_extension" property of the server.
-function lsp.get_language_id(server, doc)
-  if server.id_not_extension then
-    return server.language
-  end
-  return util.file_extension(doc.filename)
-end
-
 ---Open a document location returned by LSP
 ---@param location table
 function lsp.goto_location(location)
@@ -1056,7 +1047,7 @@ function lsp.open_document(doc)
             params = {
               textDocument = {
                 uri = util.touri(doc_path),
-                languageId = lsp.get_language_id(server, doc),
+                languageId = server:get_language_id(doc),
                 version = doc.clean_change_id,
                 text = table.concat(doc.lines)
               }
@@ -1079,7 +1070,7 @@ function lsp.open_document(doc)
             .. '"params": {\n'
             .. '"textDocument": {\n'
             .. '"uri": "'..util.touri(doc_path)..'",\n'
-            .. '"languageId": "'..lsp.get_language_id(server, doc)..'",\n'
+            .. '"languageId": "'..server:get_language_id(doc)..'",\n'
             .. '"version": '..doc.clean_change_id..',\n'
             .. '"text": "'..text..'"\n'
             .. '}\n'
@@ -1160,7 +1151,7 @@ function lsp.close_document(doc)
           params = {
             textDocument = {
               uri = util.touri(core.project_absolute_path(doc.filename)),
-              languageId = lsp.get_language_id(server, doc),
+              languageId = server:get_language_id(doc),
               version = doc.clean_change_id
             }
           }

--- a/server.lua
+++ b/server.lua
@@ -19,6 +19,10 @@ local Object = require "core.object"
 ---@alias lsp.server.notificationcb fun(server: lsp.server, params: table)
 ---@alias lsp.server.responsecb fun(server: lsp.server, response: table, request?: lsp.server.request)
 
+---@class lsp.server.languagematch
+---@field id string
+---@field pattern string
+
 ---@class lsp.server.request
 ---@field id integer
 ---@field method string
@@ -37,7 +41,7 @@ local Object = require "core.object"
 ---LSP Server communication library.
 ---@class lsp.server : core.object
 ---@field public name string
----@field public language string
+---@field public language string | lsp.server.languagematch[]
 ---@field public file_patterns table
 ---@field public current_request integer
 ---@field public init_options table
@@ -68,7 +72,7 @@ local Server = Object:extend()
 ---LSP Server constructor options
 ---@class lsp.server.options
 ---@field name string
----@field language string
+---@field language string | lsp.server.languagematch[]
 ---@field file_patterns table<integer, string>
 ---@field command table<integer, string>
 ---@field quit_timeout number
@@ -80,12 +84,17 @@ local Server = Object:extend()
 ---@field on_start? fun(server: lsp.server)
 ---@field requests_per_second number
 ---@field incremental_changes boolean
----@field id_not_extension boolean
 Server.options = {
   ---Name of the server
   name = "",
-  ---Programming language identifier
-  language = "",
+  ---Programming language identifier.
+  ---Can be a string or a table.
+  ---If the table is empty, the file extension will be used instead.
+  ---The table should be an array of tables containing `id` and `pattern`.
+  ---The `pattern` will be matched with the file path.
+  ---Will use the `id` of the first `pattern` that matches.
+  ---If no pattern matches, the file extension will be used instead.
+  language = {},
   ---Patterns to match the language files
   file_patterns = {},
   ---Command to launch LSP server and optional arguments
@@ -114,8 +123,6 @@ Server.options = {
   incremental_changes = false,
   ---True to debug the lsp client when developing it
   verbose = false,
-  ---
-  id_not_extension = false
 }
 
 ---Default timeout when sending a request to lsp server.
@@ -299,7 +306,6 @@ function Server:new(options)
 
   self.name = options.name
   self.language = options.language
-  self.id_not_extension = options.id_not_extension or false
   self.file_patterns = options.file_patterns
   self.current_request = 0
   self.init_options = options.init_options or {}
@@ -1574,6 +1580,22 @@ function Server:on_message(method, params)
       util.jsonprettify(json.encode(params))
     )
   end
+end
+
+---Return the languageId for the specified doc.
+---@param doc core.doc
+---@return string
+function Server:get_language_id(doc)
+  if type(self.language) == "string" then
+    return self.language
+  else
+    for _, l in ipairs(self.language) do
+      if string.match(doc.abs_filename, l.pattern) then
+        return l.id
+      end
+    end
+  end
+  return util.file_extension(doc.filename)
 end
 
 ---Kills the server process and deinitialize the server object state.


### PR DESCRIPTION
### [WIP]

The `language` config entry can now be either a `string` which will be used in every case, or an array.

In the array case, it's expected that each entry is a table with `id` and `pattern` properties.
The `id` represents the `languageId` to be used in the case the `pattern` matches with the file path.
Each entry is tested in order, and the first match is used.
If no match is found, the extension is used as `languageId`.

TODO:
- [x] Check if some servers fail to work properly if we send the default language as `languageId`
- [ ] Set the language table for servers that need it
- [ ] Set the proper standard name for languages that have one
- [x] Add example in `README`