### PR TITLE
Removed libraries from LuaLS config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -783,10 +783,7 @@ lspconfig.sumneko_lua = add_lsp {
         enable = true
       },
       workspace = {
-        library = {
-          DATADIR,
-          USERDIR
-        },
+        library = {},
         maxPreload = 2000,
         preloadFileSize = 1000
       },


### PR DESCRIPTION
`DATADIR` and `USERDIR` are both automatically imported as Lua libraries in the language server, even when they are not being used. Removing them reduces the memory usage of the language server.