### PR TITLE
fix(util): replace backslashes with forward ones on Windows when url-encoding

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -164,6 +164,7 @@ function util.touri(file_path)
   local function char_escape(char)
     if string.match(char, "[_.~-]") then return char end
     if char == "/" then return char end
+    if char == "\\" and PLATFORM == "Windows" then return "/" end
     return string.format("%%%02X", string.byte(char))
   end
 


### PR DESCRIPTION
This seems to be the what the `vscode-uri` node library does, which is mentioned by the LSP specs.

Related: #143.

Fixes #153.