### PR TITLE
fix(diagnostics): allow `nil` diagnostic message `severity`

### DIFF
--- a/diagnostics.lua
+++ b/diagnostics.lua
@@ -61,15 +61,15 @@ diagnostics.tag = {
 
 ---A diagnostic message.
 ---@class lsp.diagnostics.message
----@field filename string
 ---@field range lsp.diagnostics.position
----@field severity lsp.diagnostics.severity_code | integer
----@field code integer | string
----@field codeDescription lsp.diagnostics.code_description
----@field source string
+---@field severity? lsp.diagnostics.severity_code | integer
+---@field code? integer | string
+---@field codeDescription? lsp.diagnostics.code_description
+---@field source? string
 ---@field message string
----@field tags lsp.diagnostics.tag_code[]
----@field relatedInformation lsp.diagnostics.related_information
+---@field tags? lsp.diagnostics.tag_code[]
+---@field relatedInformation? lsp.diagnostics.related_information[]
+---@field data? any
 
 ---A diagnostic item.
 ---@class lsp.diagnostics.item

--- a/diagnostics.lua
+++ b/diagnostics.lua
@@ -103,7 +103,9 @@ diagnostics.lintplus_found = lintplus_found
 ---@param a lsp.diagnostics.message
 ---@param b lsp.diagnostics.message
 local function sort_helper(a, b)
-  return a.severity < b.severity
+  local a_severity = a.severity or diagnostics.severity.ERROR
+  local b_severity = b.severity or diagnostics.severity.ERROR
+  return a_severity < b_severity
 end
 
 ---Helper to catch some trange occurances where nil is given as filename
@@ -149,7 +151,9 @@ function diagnostics.get(filename, severity)
 
       local results = {}
       for _, message in ipairs(diagnostic.messages) do
-        if message.severity == severity then table.insert(results, message) end
+        if (message.severity or diagnostics.severity.ERROR) == severity then
+          table.insert(results, message)
+        end
       end
 
       return #results > 0 and results or nil
@@ -206,7 +210,9 @@ function diagnostics.get_messages_count(filename, severity)
 
   local count = 0
   for _, message in ipairs(diagnostics.list[index].messages) do
-    if message.severity == severity then count = count + 1 end
+    if (message.severity or diagnostics.severity.ERROR) == severity then
+      count = count + 1
+    end
   end
 
   return count
@@ -257,7 +263,7 @@ function diagnostics.lintplus_populate(filename)
         for _, message in pairs(diagnostic.messages) do
           local line, col = util.toselection(message.range)
           local text = message.message
-          local kind = lintplus_kinds[message.severity]
+          local kind = lintplus_kinds[message.severity or diagnostics.severity.ERROR]
 
           lintplus.add_message(fname, line, col, kind, text)
         end
@@ -268,7 +274,7 @@ function diagnostics.lintplus_populate(filename)
         for _, message in pairs(messages) do
           local line, col = util.toselection(message.range)
           local text = message.message
-          local kind = lintplus_kinds[message.severity]
+          local kind = lintplus_kinds[message.severity or diagnostics.severity.ERROR]
 
           lintplus.add_message(
             core.normalize_to_project_dir(filename),

--- a/init.lua
+++ b/init.lua
@@ -1920,7 +1920,7 @@ function lsp.view_document_diagnostics(doc)
   local indexes, captions = {}, {}
   for index, diagnostic in pairs(diagnostic_messages) do
     local line1, col1 = util.toselection(diagnostic.range)
-    local label = diagnostic_labels[diagnostic.severity]
+    local label = diagnostic_labels[diagnostic.severity or diagnostics.severity.ERROR]
       .. ": " .. diagnostic.message .. " "
       .. tostring(line1) .. ":" .. tostring(col1)
     captions[index] = label
@@ -1941,7 +1941,7 @@ function lsp.view_document_diagnostics(doc)
         local diagnostic = diagnostic_messages[indexes[name]]
         local line1, col1 = util.toselection(diagnostic.range)
         res[i] = {
-          text = diagnostics.lintplus_kinds[diagnostic.severity]
+          text = diagnostics.lintplus_kinds[diagnostic.severity or diagnostics.severity.ERROR]
             .. ": " .. diagnostic.message,
           info = tostring(line1) .. ":" .. tostring(col1),
           index = indexes[name]


### PR DESCRIPTION
The LSP specs have this field set as optional, defaulting to `Error`.

For now let's avoid setting the field when it's missing. If it becomes a problem with too many optional fields, we could add a diagnostic message normalization function.