### PR TITLE
Add more Python LSP configs

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -625,7 +625,31 @@ lspconfig.pyright = add_lsp {
   name = "pyright",
   language = "python",
   file_patterns = { "%.py$" },
-  command = { "pyright-langserver",  "--stdio" },
+  command = { "pyright-langserver", "--stdio" },
+  verbose = false
+}
+
+--# basedpyright
+--- __Status__: Works
+--- __Site__: https://github.com/DetachHead/basedpyright
+--- __Installation__: `pip install basedpyright`  or `npm install -g basedpyright`
+lspconfig.basedpyright = add_lsp {
+  name = "basedpyright",
+  language = "python",
+  file_patterns = { "%.py$" },
+  command = { "basedpyright-langserver", "--stdio" },
+  verbose = false
+}
+
+--# ruff
+--- __Status__: Works
+--- __Site__: https://github.com/astral-sh/ruff
+--- __Installation__: `pip install ruff` or `uv tool install ruff`
+lspconfig.ruff = add_lsp {
+  name = "ruff",
+  language = "python",
+  file_patterns = { "%.py$" },
+  command = { "ruff", "server" },
   verbose = false
 }
 


### PR DESCRIPTION
This PR adds a few more LSPs for Python.

**Basedpyright**: a fork of pyright with various improvements. It shares a lot of the same config parameters as pyright.
https://docs.basedpyright.com/latest/
https://docs.basedpyright.com/latest/configuration/language-server-settings/

**Ruff**: formatter and linter in a single, common backend, it does not currently provide navigation and autocompletion, so it's intended to be used alongside something like `basedpyright` or `pylsp`. However, it's super useful by itself as it replaces many tools already.
https://docs.astral.sh/ruff/
https://docs.astral.sh/ruff/editors/
https://astral.sh/blog/ruff-v0.4.5

