### PR TITLE
Add separator between `result.contents` of `textDocument/hover`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1573,14 +1573,16 @@ function lsp.request_hover(doc, line, col, in_tab)
                 text = content.value
                 if content.kind then kind = content.kind end
               else
+                local texts = {}
                 for _, element in pairs(content) do
                   if type(element) == "string" then
-                    text = text .. element
+                    table.insert(texts, element)
                   elseif type(element) == "table" and element.value then
-                    text = text .. element.value
+                    table.insert(texts, element.value)
                     if not kind and element.kind then kind = element.kind end
                   end
                 end
+                text = table.concat(texts, "\n\n")
               end
             else -- content should be a string
               text = content


### PR DESCRIPTION
There was no separator between `result.contents` when hovering:
<img width="2196" height="227" alt="image" src="https://github.com/user-attachments/assets/77e52288-e2eb-472c-aae9-2e6e7aea3763" />

After this fix:
<img width="1674" height="304" alt="image" src="https://github.com/user-attachments/assets/17be3bcd-f08c-4fe9-9bf8-e6f47d8b8eae" />

Raw data from `textDocument/hover` is like:
```
{
  "result": {
    "contents": [
      {
        "language": "java",
        "value": "void java.io.PrintStream.println(String x)"
      },
      "Prints a String and then terminates the line. This method behaves as though it invokes print(String) and then println().\r\n\r\n *  **Parameters:**\r\n    \r\n     *  **x** The `String` to be printed."
    ]
  },
  "id": 2,
  "jsonrpc": "2.0"
}
```

So between elements of `result.contents` there should be a separator.