### PR TITLE
Kludge to fix multiple autocomplete suggestions with the same label (such as overloads)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1419,6 +1419,15 @@ function lsp.request_completion(doc, line, col, forced)
             desc = desc:gsub("[%s\n]+$", "")
               :gsub("\n\n\n+", "\n\n")
 
+            if lsp.servers[server.name].replace_label then
+              local chars = {"\u{0}", "\u{1}", "\u{2}", "\u{3}", "\u{4}", "\u{5}", "\u{6}", "\u{7}", "\u{8}", "\u{9}"}
+              local toAdd = ""
+              local symbolCountStr = tostring(symbol_count)
+              for i=1, #symbolCountStr do
+                toAdd = toAdd .. chars[tonumber(symbolCountStr:sub(i, i)) + 1]
+              end
+              label = label .. toAdd
+            end
             symbols.items[label] = {
               info = info,
               desc = desc,


### PR DESCRIPTION
This is to fix an issue I've encountered: if there are multiple autocomplete suggestions with the same label (for example, the different overloads of the `ArrayList` constructor if I'm using jdtls), all but one will be hidden. This fix uses a hideous kludge of adding invisible characters to the end of the label to make each suggestion have a unique label. This is only applied on servers with the replace_label property set to true.

I'm creating this pull request so that others may use this fix until there's a better solution. I'm interested if anyone can think of a better solution.