### PR TITLE
add mocked client/registerCapability listener

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -806,6 +806,16 @@ function lsp.start_server(filename, project_directory)
           end
         end
 
+
+        -- Respond to client/registerCapability request
+        -- Note: This response ensures certain LSP servers to continue processing
+        client:add_request_listener(
+          "client/registerCapability",
+          function(server, request)
+            server:push_response(request.method, request.id, json.null)
+          end
+        )
+
         -- Respond to workspace/configuration request
         client:add_request_listener(
           "workspace/configuration",


### PR DESCRIPTION
Without `client/registerCapability ` listener server will receive 'Method not found' error and will causing it to not move forward with requests.

I had the issue with Elixir language server [Expert](https://github.com/expert-lsp/expert)
Similar issue on other LSP server: this https://github.com/anthropics/claude-code/issues/32595

